### PR TITLE
docs: add FCACore business Agent plugin guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2011,6 +2011,27 @@
                 "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory", "zh-CN/AGENTS"]
               }
             ]
+          },
+          {
+            "tab": "业务 Agent 插件",
+            "groups": [
+              {
+                "group": "FCACore 业务 Agent 插件",
+                "icon": "blocks",
+                "pages": [
+                  "zh-CN/fcacore-agent-plugins/index",
+                  "zh-CN/fcacore-agent-plugins/getting-started",
+                  "zh-CN/fcacore-agent-plugins/plugin-runtime",
+                  "zh-CN/fcacore-agent-plugins/agent-skill-manifest",
+                  "zh-CN/fcacore-agent-plugins/tool-integration",
+                  "zh-CN/fcacore-agent-plugins/governance-testing",
+                  "zh-CN/fcacore-agent-plugins/realtime-websocket",
+                  "zh-CN/fcacore-agent-plugins/desktop-browser",
+                  "zh-CN/fcacore-agent-plugins/toolpack",
+                  "zh-CN/fcacore-agent-plugins/nfe-capabilities"
+                ]
+              }
+            ]
           }
         ]
       },

--- a/docs/zh-CN/fcacore-agent-plugins/agent-skill-manifest.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/agent-skill-manifest.mdx
@@ -1,0 +1,118 @@
+---
+title: "Agent、Skill 与 Manifest"
+sidebarTitle: "Agent 与 Skill"
+description: "定义双 Manifest、Agent 岗位责任、Skill 工作流和参数来源规则。"
+icon: "bot"
+---
+
+## 双 Manifest
+
+`.codex-plugin/plugin.json` 声明 Codex 组件：
+
+- Skill 根目录；
+- MCP Server；
+- UI 展示信息。
+
+`.fcacore-plugin/plugin.json` 声明 FCACore 业务治理：
+
+- 专家类型与 Agent；
+- 岗位、职责和移交；
+- 工具白名单；
+- 插件命令工具；
+- ToolPack capability/operation 依赖；
+- 权限和审批策略。
+
+两个 Manifest 的 `name`、`version` 必须一致，目录名必须等于 `name`。
+
+## 插件命令工具
+
+```json
+{
+  "pluginCapabilities": {
+    "tools": [
+      {
+        "name": "customer_lookup",
+        "description": "按唯一客户编号读取客户资料。",
+        "command": "node \"$FCACORE_PLUGIN_ROOT/adapters/plugin-tool.mjs\"",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "customer_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["customer_id"],
+          "additionalProperties": false
+        }
+      }
+    ]
+  }
+}
+```
+
+运行时提供：
+
+| 环境变量 | 内容 |
+| --- | --- |
+| `FCACORE_PLUGIN_ROOT` | 已安装插件根目录 |
+| `AEON_TOOL_NAME` | 当前工具名 |
+| `AEON_TOOL_INPUT` | JSON 字符串参数 |
+
+命令必须固定。不能把用户输入拼接进 `command`。
+
+## Agent 规范
+
+Agent 文件定义长期岗位行为，至少包含：
+
+- 使命；
+- `owns` 和 `doesNotOwn`；
+- 参数与事实来源；
+- 工具选择规则；
+- 写操作审批边界；
+- 失败和移交；
+- 输出合同。
+
+不要在 Agent 文件中复制完整 API 文档、写入凭据、声明未授予权限或把工具发现结果当成执行成功。
+
+一个插件默认只包含一个责任清晰的 Agent。只有确实存在独立岗位和移交关系时才引入专家团队。
+
+## Skill 规范
+
+Skill frontmatter 只包含：
+
+```yaml
+---
+name: create-order
+description: 核验订单资料并生成可审批建单草稿。用户要求创建订单、导入托书、检查建单缺项或提交订单时使用。
+---
+```
+
+`description` 同时描述能力和触发场景。SKILL.md 只保留：
+
+- 工具选择；
+- 固定流程；
+- 阻断条件；
+- 资源导航；
+- 完成门。
+
+字段合同和协议放 `references/`，确定性转换放 `scripts/`。
+
+`agents/openai.yaml` 的默认提示必须显式引用 Skill：
+
+```yaml
+interface:
+  display_name: "订单创建"
+  short_description: "核验订单资料并生成可审批建单草稿和回读证据"
+  default_prompt: "使用 $create-order 核验资料并准备建单草稿。"
+policy:
+  allow_implicit_invocation: true
+```
+
+## 参数规则
+
+- 只接受用户输入、附件解析结果或真实工具返回。
+- Schema 对稳定业务动作使用 `additionalProperties: false`。
+- 不为了减少追问而给未知业务字段设置默认值。
+- 候选不唯一时返回 `input_required`。
+- 空结果是有效结果，不补造记录。

--- a/docs/zh-CN/fcacore-agent-plugins/desktop-browser.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/desktop-browser.mdx
@@ -1,0 +1,103 @@
+---
+title: "桌面与浏览器"
+description: "在业务 API、Browser 和 Computer Use 之间选择正确执行入口。"
+icon: "monitor-cog"
+---
+
+## 路由原则
+
+| 目标 | 执行入口 |
+| --- | --- |
+| 有稳定企业 API | ToolPack、插件工具或 MCP |
+| FCACore 内置浏览器网页 | `Browser*` |
+| macOS 原生应用 | `ComputerUsePlugin` 与规范化 Computer Use 工具 |
+| 用户明确要求操作已有外部 Chrome 窗口 | 专用外部浏览器桥 |
+
+优先顺序：
+
+```text
+Business API / ToolPack
+-> Browser DOM/CDP
+-> macOS Accessibility
+-> explicit pointer fallback
+```
+
+## 规范化桌面工具
+
+| 类别 | 工具 | 权限 |
+| --- | --- | --- |
+| 发现 | `ComputerUsePlugin`、`list_apps` | 按动作判断 / ReadOnly |
+| 观察 | `get_app_state` | ReadOnly |
+| 元素动作 | `click`、`perform_secondary_action` | WorkspaceWrite |
+| 表单 | `set_value`、`select_text` | WorkspaceWrite |
+| 导航 | `scroll`、`drag` | WorkspaceWrite |
+| 输入 | `press_key`、`type_text` | WorkspaceWrite |
+
+插件不应自行实现原始鼠标键盘驱动。
+
+<Info>
+  读取动作使用 `ReadOnly`；点击、输入、滚动和拖动属于 `WorkspaceWrite`，并按当前 AgentPermissionPolicy 决定是否审批。
+</Info>
+
+## 执行循环
+
+```text
+list_apps（目标不明确时）
+-> get_app_state
+-> 使用最新 state_id/generation_id 或可验证语义目标
+-> 执行一个动作
+-> fresh get_app_state
+-> verify
+```
+
+不要缓存 UI 节点跨窗口更新使用。键盘输入要求目标应用位于前台并携带验证条件；坐标 fallback 遵循宿主审批策略。
+
+<Warning>
+  工具返回“动作已投递”不代表业务目标完成。必须重新读取应用状态并验证预期结果。
+</Warning>
+
+示例：
+
+- `examples/desktop-tools/fcacore-plugin.fragment.json`
+- `examples/desktop-tools/observe-act-verify.workflow.json`
+
+工作流中的 `$steps.*` 是编排器数据引用，执行前必须替换成上一步的真实返回值。
+
+## 高级 Computer Use
+
+规范化工具无法覆盖定位、审计或复杂计划时，可通过 `ComputerUsePlugin` 路由：
+
+- 观察定位：`computer_use.snapshot`、`observe_state`、`find_node`、`window_list`；
+- 动作：`press_node`、`click`、`double_click`、`right_click`、`set_value`、`type_text`、`hotkey`、`scroll`、`drag`、`focus_app`；
+- 等待验证：`wait_for`、`verify`；
+- 计划执行：`execute_plan`、`dry_run_controlled_task`、`execute_controlled_task`；
+- 审计恢复：`list_runs`、`get_run`、`get_run_steps`、`get_trace`、`clear_old_runs`；
+- 浏览器虚拟控制桥：`browser_click`、`browser_set_value`。
+
+`clipboard` 可能处理敏感数据，只在业务确实需要且策略允许时使用。
+
+## 浏览器工具
+
+普通网页流程保持在同一个 Agent Browser 会话：
+
+```text
+BrowserOpen
+-> BrowserSnapshot / BrowserGet
+-> BrowserClick / BrowserFill / BrowserPress / BrowserScroll
+-> BrowserSnapshot / BrowserGet
+-> verify
+```
+
+还可使用 `BrowserFind`、`BrowserWait`、`BrowserTab`、`BrowserScreenshot`、`BrowserUpload` 和网络请求观测工具。不要在网页流程中无故切换到 Computer Use。
+
+## macOS 权限
+
+桌面执行可能需要：
+
+- Accessibility；
+- Screen Recording；
+- Automation；
+- Input Monitoring；
+- Full Disk Access。
+
+是否需要具体权限取决于动作和后端。业务插件必须保持权限声明、工具白名单和实际操作一致。

--- a/docs/zh-CN/fcacore-agent-plugins/getting-started.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/getting-started.mdx
@@ -1,0 +1,5 @@
+---
+title: "快速开始"
+description: "复制 FCACore 业务 Agent 插件模板，裁剪不需要的能力并完成首次校验。"
+icon: "rocket"
+---

--- a/docs/zh-CN/fcacore-agent-plugins/governance-testing.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/governance-testing.mdx
@@ -1,0 +1,101 @@
+---
+title: "治理、测试与发布"
+sidebarTitle: "治理与发布"
+description: "落实写操作审批、证据合同、最低测试集和插件发布检查。"
+icon: "shield-check"
+---
+
+## 写操作生命周期
+
+```text
+session/health
+-> facts
+-> readiness
+-> preflight
+-> draft
+-> approval
+-> execute
+-> verify
+```
+
+审批至少绑定：
+
+- operation；
+- target ID；
+- payload hash；
+- actor；
+- expiry；
+- 单次使用令牌。
+
+模型不能生成 `approved_by` 或伪造 approval ID。宿主验证审批后把受信状态注入执行上下文。
+
+执行器必须校验幂等键、拒绝未知 operation、限制目标环境、记录 request ID、返回真实业务 ID，并支持独立回读。
+
+<Warning>
+  不要根据模型文本、请求字段或客户端自报状态判断“已经审批”。审批只能来自宿主验证后的受信执行上下文。
+</Warning>
+
+## 证据合同
+
+交付证据至少包含：
+
+- 来源类型；
+- 工具或 capability；
+- request ID；
+- 读取时间；
+- 目标记录 ID；
+- 是否产生副作用；
+- 写后回读结果。
+
+工具发现、计划文本和“请求已发送”都不是业务成功证据。
+
+## 最低测试集
+
+1. Manifest 名称、版本和路径；
+2. Skill 典型触发和不应触发场景；
+3. 参数缺失和未知字段；
+4. 候选不唯一；
+5. 登录失效；
+6. HTTP/WS/MCP 超时；
+7. 空结果；
+8. 写操作无审批；
+9. 审批作用域不匹配；
+10. 幂等重复；
+11. 执行后回读不匹配；
+12. 凭据扫描。
+
+模板测试不得连接生产系统或产生外部写入。
+
+<Danger>
+  自动化测试禁止使用生产凭据，也禁止调用真实建单、扣款、发信或其他不可逆接口。
+</Danger>
+
+## 校验命令
+
+```bash
+npm run check
+
+python3 /Users/opnclaw/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .
+python3 /Users/opnclaw/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/<skill-id>
+```
+
+NFE ToolPack：
+
+```bash
+node ../../toolpacks/nfe-logistics/scripts/validate-toolpack.mjs
+```
+
+## 发布检查
+
+- [ ] 插件目录和双 Manifest 名称一致。
+- [ ] 双 Manifest 使用相同语义化版本。
+- [ ] 只声明真实存在的 Agent、Skill、MCP 和工具。
+- [ ] Agent 的职责、排除项、交付物和移交可验收。
+- [ ] Skill description 覆盖真实触发表达。
+- [ ] 工具 Schema 不接受无关字段。
+- [ ] 没有任意 URL、任意命令和任意 operation。
+- [ ] 凭据没有进入代码、Manifest、日志和返回值。
+- [ ] 写操作经过草稿、审批、幂等执行和回读。
+- [ ] Agent 只依赖最小 Capability Set。
+- [ ] 正向、空结果、认证失败和审批失败测试通过。
+- [ ] 模板和官方校验通过。

--- a/docs/zh-CN/fcacore-agent-plugins/index.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/index.mdx
@@ -1,0 +1,110 @@
+---
+title: "FCACore 业务 Agent 插件开发"
+description: "开发可发现、可授权、可执行、可审计的 FCACore 企业业务 Agent 插件。"
+icon: "blocks"
+keywords: ["FCACore", "Agent 插件", "业务插件", "ToolPack"]
+---
+
+本目录说明怎样在 FCACore 中开发可发现、可授权、可执行、可审计的业务 Agent 插件。文档只描述当前模板和仓库已经实现的合同，不把规划中的能力写成已交付功能。
+
+## 从哪里开始
+
+<Columns cols={3}>
+  <Card title="快速开始" icon="rocket" href="/zh-CN/fcacore-agent-plugins/getting-started">
+    复制模板、裁剪示例并完成第一次校验。
+  </Card>
+
+  <Card title="运行架构" icon="workflow" href="/zh-CN/fcacore-agent-plugins/plugin-runtime">
+    理解 Agent、Skill、Tool、ToolPack 与 Transport 的边界。
+  </Card>
+
+  <Card title="Agent 与 Skill" icon="bot" href="/zh-CN/fcacore-agent-plugins/agent-skill-manifest">
+    编写双 Manifest、岗位职责和任务流程。
+  </Card>
+
+  <Card title="工具接入" icon="plug" href="/zh-CN/fcacore-agent-plugins/tool-integration">
+    接入 CLI、HTTP、MCP 和外部自建接口。
+  </Card>
+
+  <Card title="实时 WebSocket" icon="radio" href="/zh-CN/fcacore-agent-plugins/realtime-websocket">
+    用常驻 MCP 管理订阅、心跳、重连和事件游标。
+  </Card>
+
+  <Card title="桌面与浏览器" icon="monitor-cog" href="/zh-CN/fcacore-agent-plugins/desktop-browser">
+    选择 Browser 或 Computer Use 并执行状态验证。
+  </Card>
+
+  <Card title="ToolPack" icon="package" href="/zh-CN/fcacore-agent-plugins/toolpack">
+    设计企业能力合同、能力集、审批和回读。
+  </Card>
+
+  <Card title="NFE 能力参考" icon="list-tree" href="/zh-CN/fcacore-agent-plugins/nfe-capabilities">
+    查询 NFE ToolPack 当前 capability 和合同完整度。
+  </Card>
+
+  <Card title="治理与发布" icon="shield-check" href="/zh-CN/fcacore-agent-plugins/governance-testing">
+    检查权限、审批、证据、测试和发布门。
+  </Card>
+</Columns>
+
+## 架构
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '14px'}}}%%
+flowchart LR
+    U["用户目标"] --> A["Agent<br/>岗位责任"]
+    A --> S["Skill<br/>业务流程"]
+    S --> T{"选择执行前门"}
+    T --> P["插件命令工具<br/>轻量调用"]
+    T --> M["MCP Server<br/>外部工具与实时连接"]
+    T --> E["EnterpriseTool<br/>ToolPack"]
+    T --> D["Computer Use / Browser<br/>界面操作"]
+    P --> V["证据与回读"]
+    M --> V
+    E --> V
+    D --> V
+
+    classDef client fill:#3B82F6,stroke:#2563EB,color:#fff,stroke-width:2px
+    classDef service fill:#10B981,stroke:#059669,color:#fff,stroke-width:2px
+    classDef gateway fill:#F59E0B,stroke:#D97706,color:#fff,stroke-width:2px
+    classDef external fill:#F43F5E,stroke:#E11D48,color:#fff,stroke-width:2px
+    classDef data fill:#8B5CF6,stroke:#7C3AED,color:#fff,stroke-width:2px
+
+    class U client
+    class A,S service
+    class T gateway
+    class P,M,E,D external
+    class V data
+```
+
+## 文档边界
+
+```text
+architecture/   稳定概念、运行时发现和执行因果
+guides/         插件开发者可执行步骤
+integrations/   特定协议和宿主工具
+toolpacks/      企业业务能力包合同
+reference/      自动生成或查阅型清单
+```
+
+维护规则：
+
+- 一个事实只保留一个权威位置，其他文档使用链接。
+- `reference/nfe-capabilities.mdx` 由脚本生成，不手工修改能力行。
+- 示例参数必须来自真实 Schema，不用猜测值填满字段。
+- 文档中的“支持”必须能在 Manifest、代码或测试中找到对应实现。
+- 新增文档后同步更新 `docs.json` 和 `scripts/validate.mjs`。
+
+## 快速校验
+
+在插件模板根目录运行：
+
+```bash
+npm run check
+```
+
+该命令重新生成 NFE 参考、校验目录合同并执行无外部副作用测试。
+
+<Tip>
+  在 `docs/` 目录运行 `npx mint dev` 可以启动带热更新的本地文档站。
+</Tip>

--- a/docs/zh-CN/fcacore-agent-plugins/nfe-capabilities.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/nfe-capabilities.mdx
@@ -1,0 +1,281 @@
+---
+title: "NFE ToolPack 能力参考"
+sidebarTitle: "NFE 能力参考"
+description: "由 NFE Manifest 自动生成的 capability 分类、风险、审批和合同完整度清单。"
+icon: "list-tree"
+---
+
+> 此页面由 `npm run generate:nfe-reference` 根据 `toolpacks/nfe-logistics/manifest.json` 生成，请勿手工维护能力行。
+
+- ToolPack：`nfe-logistics`
+- 版本：`1.3.0`
+- Manifest：`toolpack.manifest/v1`
+- Capability 数量：`111`
+- 统一执行前门：`EnterpriseTool`
+- 入口：`bin/macos-arm64/nfe-tool-wrapper`
+- 登录器：`bin/macos-arm64/nfe-login-wrapper`
+
+## 使用原则
+
+1. 先用 ToolSearch 或业务 Skill 找到 capability，再通过 EnterpriseTool 调用。
+2. `read_only` 能力读取事实；写入只能进入已审批执行器。
+3. 发现结果不是执行证据；写入后必须调用只读能力回读。
+4. 输入必须通过对应 JSON Schema，未声明字段不得传递。
+
+## 当前合同完整度
+
+| 字段 | 缺失能力数 |
+| --- | --: |
+| `contract` | 110 |
+| `examples` | 109 |
+| `error_codes` | 110 |
+| `business_preconditions` | 108 |
+| `empty_result_meaning` | 108 |
+
+这些数字是治理待办，不表示 capability 当前不可调用。新能力不得继续复制缺失合同的旧形态。
+
+## 分类索引
+
+| 分类 | 数量 |
+| --- | --: |
+| 班列 | 1 |
+| 财务 | 15 |
+| 舱位 | 3 |
+| 单证 | 1 |
+| 订单 | 17 |
+| 风控 | 3 |
+| 基础数据 | 23 |
+| 经营统计 | 2 |
+| 设备追踪 | 3 |
+| 通知公告 | 1 |
+| 托书建单 | 10 |
+| 系统安全 | 2 |
+| 业务操作 | 4 |
+| 业务操作系统 | 4 |
+| 业务聚合 | 6 |
+| 运营管理 | 3 |
+| Atom | 3 |
+| Auth | 1 |
+| Catalog | 2 |
+| Order | 1 |
+| Page | 6 |
+
+## 班列
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_train_numbers` | 查询班列号列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询可选班列号，用于订单履约、班列发运和运踪匹配。 |
+
+## 财务
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_bill_detail` | 查询账单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_bill_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据账单唯一标识 ID 获取账单的详细应收/应付金额、币种、费项、发票及核销状态明细数据。 |
+| `nfe.query_bill_receivables` | 查询应收账单 | `read_only` | `low` | 否 | `schemas/nfe.query_finance_ar.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按日期范围获取已经向托运人或客户方正式开出并确认对账的应收客户对账单列表。 |
+| `nfe.query_booking_fees` | 查询订单全量费用明细 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_fees.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据整型订单 ID 查询订单下的全量收支费用、应收应付、汇率及利润核算明细列表数据。 |
+| `nfe.query_booking_profit` | 查询订单利润核算 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_profit.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 和费用公司查询订单利润核算结果，用于亏损、微利和报价复盘。 |
+| `nfe.query_booking_revenue_stat` | 查询订单收入统计 | `read_only` | `low` | 否 | `schemas/nfe.booking_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询订单收入统计，用于核对应收、利润和报价闭环。 |
+| `nfe.query_charge_item_tree` | 查询费用项目树 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询费用项目树，用于报价、应收、应付和费用归类。 |
+| `nfe.query_client_tax_info` | 查询客户税务开票信息 | `read_only` | `low` | 否 | `schemas/nfe.client_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据客户 ID 查询客户税务和开票信息，用于开票前核对。 |
+| `nfe.query_fee_approve_count` | 查询费用审批数量 | `read_only` | `low` | 否 | `schemas/nfe.booking_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询费用审批数量，用于判断费用是否存在未完成审批。 |
+| `nfe.query_finance_ap` | 查询应付费用 | `read_only` | `low` | 否 | `schemas/nfe.query_finance_ar.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按日期范围统计并查询应向供应商、铁路局支付的多币种应付款项明细流水表。 |
+| `nfe.query_finance_ar` | 查询应收费用 | `read_only` | `low` | 否 | `schemas/nfe.query_finance_ar.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按日期范围统计并查询业务系统中的账单应收明细，用于财务核对与收入分析。 |
+| `nfe.query_invoice_payable` | 查询应付发票 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询收到并登记入账的来自外部运力、堆场、港区服务供应商的进项发票总表。 |
+| `nfe.query_invoice_receivable` | 查询应收发票 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询已经向客户正式开具的销项增值税发票记录或回执登记信息列表。 |
+| `nfe.query_nearby_month_rate` | 查询附近月份汇率 | `read_only` | `low` | 否 | `schemas/nfe.query_nearby_month_rate.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按费用日期查询附近月份汇率，用于应收应付和报价币种换算。 |
+| `nfe.query_pay_apply` | 查询我的支付申请 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取当前员工或运营小组发起的所有对外付款审批流程与支付执行单列表。 |
+| `nfe.query_virtual_booking_profit` | 查询虚拟订单利润信息 | `read_only` | `low` | 否 | `schemas/nfe.booking_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询虚拟订单利润信息，用于集拼、虚拟订单和利润拆分分析。 |
+
+## 舱位
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_fcl_space` | 查询整箱舱位 | `read_only` | `low` | 否 | `schemas/nfe.query_fcl_space.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询铁路运输的整箱(FCL)舱位余量、计划起开日期以及价格运价本数据。 |
+| `nfe.query_lcl_space` | 查询拼箱舱位 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页查询班列货运拼箱(LCL)最新计划公布及空闲舱位报价明细。 |
+| `nfe.query_position_list` | 查询舱位管理列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页获取业务中心当前已分配、占满或预定的舱位管理条目总表。 |
+
+## 单证
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_customs_detail` | 查询订单报关详情 | `read_only` | `low` | 否 | `schemas/nfe.booking_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询报关详情，用于单证、报关草单、正式报关和放行判断。 |
+
+## 订单
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_air_order_detail` | 查询空运订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单唯一标识 ID 精确查询空运订单的详细状态、航班节点及明细数据。 |
+| `nfe.query_air_orders` | 查询空运订单列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按起运日期范围分页获取航空货运包机或者散货空运的订单总表。 |
+| `nfe.query_booking_detail` | 查询订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 精确查询铁路订单的全部详细状态、节点跟踪及明细数据。 |
+| `nfe.query_cargo_list` | 查询订单货物明细 | `read_only` | `low` | 否 | `schemas/nfe.booking_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询货物件毛体、品名、包装、HS code 等明细，用于报价、单证和报关校验。 |
+| `nfe.query_ocean_orders` | 查询海运订单列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取国际海运散货、集装箱及多式联运订单的多条件组合分页列表。 |
+| `nfe.query_order_detail_by_mode` | 按运输模式查询订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_order_detail_by_mode.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 和运输模式自动分派到铁路、海运、空运、卡车、租箱或其它订单详情查询能力；用于业务编排中的兼容入口。 |
+| `nfe.query_order_template_detail` | 查询订单模板详情 | `read_only` | `low` | 否 | `schemas/nfe.query_order_template_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据模板唯一标识 ID 查询订单模板的详细预设费用、港口及舱位基础配置数据。 |
+| `nfe.query_order_templates` | 查询订单模板列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取系统内置的快速生成重复多频次国际大宗物流订单模板列表。 |
+| `nfe.query_other_order_detail` | 查询其它订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单唯一标识 ID 精确查询仓储、报关等其它增值代理服务类订单的详细状态及业务明细数据。 |
+| `nfe.query_other_orders` | 查询其它业务订单列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询仓储、报关、商检等其它延伸增值代理服务类的订单总表。 |
+| `nfe.query_rail_orders` | 查询铁路整拼订单列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页获取全部铁路整箱和拼箱运输订单的业务列表。 |
+| `nfe.query_rent_container_order_detail` | 查询租箱订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单唯一标识 ID 精确查询集装箱租赁订单的提空、还箱及相关堆场租借状态明细数据。 |
+| `nfe.query_rent_container_orders` | 查询租箱业务订单列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取集装箱租赁、堆场提空箱与还箱业务的专项租赁订单列表。 |
+| `nfe.query_sea_order_detail` | 查询海运订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单唯一标识 ID 精确查询海运订单的详细状态、运力节点及明细数据。 |
+| `nfe.query_truck_order_detail` | 查询国际卡车订单详情 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单唯一标识 ID 精确查询跨境卡车运输订单的详细状态、口岸放行及物流节点数据。 |
+| `nfe.query_truck_orders` | 查询国际卡车订单列表 | `read_only` | `low` | 否 | `schemas/paged_date_range.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按日期范围分页获取公路公路卡车跨境物流运输的业务订单列表。 |
+| `nfe.quick_search` | 订单速查 | `read_only` | `low` | 否 | `schemas/nfe.quick_search.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按订单号、箱号、HSCode、起运港和目的港快速检索物流订单列表。 |
+
+## 风控
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.match_special_prohibited_cargo_hs_code` | 匹配HS Code敏感禁运风险 | `read_only` | `low` | 否 | `schemas/nfe.match_special_prohibited_cargo_hs_code.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按 HS Code 调用 NFE 真实敏感/禁运匹配接口，返回是否命中及相似 HS Code。 |
+| `nfe.query_special_prohibited_cargo_categories` | 查询敏感禁运货品分类 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询特殊/禁运货品分类，用于询盘、报价和接单前风险识别。 |
+| `nfe.query_special_prohibited_cargo_list` | 查询敏感禁运货品清单 | `read_only` | `low` | 否 | `schemas/nfe.query_special_prohibited_cargo_list.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按真实分类 ID 查询特殊/禁运货品清单，返回 HS Code、品名、线路、口岸和总数等信息。 |
+
+## 基础数据
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_city_levels` | 查询城市层级数据 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取全国以及相关合作城市的物流区域与行政层级级别字典数据。 |
+| `nfe.query_client_account` | 查询客户账号信息 | `read_only` | `low` | 否 | `schemas/nfe.client_id.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据客户 ID 查询客户账号信息，用于订单客户、托书和收发通核对。 |
+| `nfe.query_config_value` | 查询系统配置值 | `read_only` | `low` | 否 | `schemas/nfe.query_config_value.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按配置键查询 NFE 系统配置，用于报价比例、订单参数等系统规则读取。 |
+| `nfe.query_countries` | 查询国家字典列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取全球各个国家的中英文双语标准缩写与国家字典主数据。 |
+| `nfe.query_custom_view` | 查询自定义视图列表 | `read_only` | `low` | 否 | `schemas/nfe.query_custom_view.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据特定视图类型编码获取对应的系统用户自定义看板或者数据表格布局视图。 |
+| `nfe.query_dashboard_bookings` | 查询Dashboard接单列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页拉取客服/运营工作台待确认或近期已处理的接单数据列表。 |
+| `nfe.query_dashboard_month_graph` | 查询Dashboard月度绩效 | `read_only` | `low` | 否 | `schemas/nfe.query_dashboard_month_graph.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按月份读取首页月度绩效图表数据，用于判断拼箱、整箱和其它订单的月度趋势。 |
+| `nfe.query_dashboard_stats` | 查询Dashboard统计 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 读取首页客服单证工作台统计卡片，包括待受理订单、待收账运费单和待开票金额等真实指标。 |
+| `nfe.query_dict_type` | 查询数据字典值 | `read_only` | `low` | 否 | `schemas/nfe.query_dict_type.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据具体的字典类型编码，获取其对应的映射名值对数据（如箱型、业务状态等）。 |
+| `nfe.query_dict_type_detail` | 查询数据字典详情 | `read_only` | `low` | 否 | `schemas/nfe.query_dict_type_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按字典数据 ID 查询系统字典明细，用于核对后台字典配置。 |
+| `nfe.query_exit_ports` | 查询出境口岸列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询陆运/铁路运输中支持的出境关口/口岸字典列表。 |
+| `nfe.query_fee_company` | 查询费用公司列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 查询铁大大系统的结算费用公司列表（如宁波铁大大、铁达达物流等）。 |
+| `nfe.query_loading_warehouses` | 查询装货堆场仓库列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页获取系统中全部装货堆场、海运集港/提箱仓库的地址及联系人信息列表数据。 |
+| `nfe.query_overseas_ports` | 查询海外港口列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取海外清关、派送和目的港物流场景使用的海外港口/站点字典列表。 |
+| `nfe.query_platform_rate` | 查询平台实时汇率 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取系统内置的各种币种之间进行结算核对的平台最新即期汇率表。 |
+| `nfe.query_ports` | 查询全部港口列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取系统内支持的所有海运及铁路线路起运港/目的港口主字典数据。 |
+| `nfe.query_ports_list` | 查询港口搜索列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 提供带分页的港口、铁路线路站点模糊搜索匹配列表数据接口。 |
+| `nfe.query_railway_ports` | 查询铁路口岸列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 专用于获取中欧/中亚班列线路的主要铁路过境和出入境口岸字典列表。 |
+| `nfe.query_sales` | 查询销售人员列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取在职销售顾问/客户经理列表，用于订单分配与跟进人查询。 |
+| `nfe.query_suppliers` | 查询供应商列表 | `read_only` | `low` | 否 | `schemas/nfe.query_suppliers.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按类别过滤并查询合作的物流或运力供应商列表数据。 |
+| `nfe.query_users_all` | 查询全部用户下拉列表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取系统内所有用户员工的下拉列表，主要用于客服或业务跟进人选择过滤。 |
+| `nfe.query_warehouse_options` | 查询仓库堆场选项 | `read_only` | `low` | 否 | `schemas/nfe.query_warehouse_options.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按仓库类型和港口 ID 查询装箱仓、集货仓、海港仓等供应商仓库选项。 |
+| `nfe.search_client` | 搜索客户信息 | `read_only` | `low` | 否 | `schemas/nfe.search_client.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按客户名称搜索客户扩展/下拉信息，用于询盘归属、订单客户和开票客户识别。 |
+
+## 经营统计
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_lcl_container_opening_stats` | 查询拼箱开柜统计 | `read_only` | `low` | 否 | `schemas/nfe.query_lcl_container_opening_stats.input.json` | contract, error\_codes | 按明确日期范围读取 NFE 拼箱仓位管理看板，统计已发布的拼箱集拼柜记录；用于回答本周拼箱开了几个柜子。 |
+| `nfe.query_lcl_operation_stats` | 查询拼箱运营统计 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes | 读取 NFE 拼箱运营 Dashboard 的实时待配箱、待装箱统计；该接口不提供按周开柜数量。 |
+
+## 设备追踪
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_booking_containers` | 查询订单集装箱列表 | `read_only` | `low` | 否 | `schemas/nfe.query_booking_detail.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单 ID 查询该订单下绑定的全部集装箱（箱号、封号、箱型及状态）列表数据。 |
+| `nfe.query_geo_fences` | 查询电子围栏列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页查询系统定义的全部电子地理围栏及经纬度覆盖区域列表数据。 |
+| `nfe.query_gps_devices` | 查询GPS设备列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取物流集装箱在途追踪中使用的GPS追踪绑定的硬件定位设备详情列表。 |
+
+## 通知公告
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.check_messages` | 查询系统站内信与通知 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 分页拉取系统自动推送的异常状态预警、审核流待办或者其它系统站内信通知列表。 |
+
+## 托书建单
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.build_human_clarification` | 生成人工澄清问题 | `read_only` | `low` | 否 | `schemas/nfe.build_human_clarification.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把建单 blockers、候选客户、候选班列和缺失字段整理成一次性人工确认问题。 |
+| `nfe.compose_rail_fcl_order_payload` | 组装铁路整箱建单 Payload 草案 | `read_only` | `medium` | 否 | `schemas/nfe.compose_rail_fcl_order_payload.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把托书字段、客户上下文和路线班列上下文组装为 rail\_add payload 草案，并调用本地预检；该能力不会创建订单。 |
+| `nfe.compose_rail_lcl_order_payload` | 组装铁路拼箱建单 Payload 草案 | `read_only` | `medium` | 否 | `schemas/nfe.compose_rail_lcl_order_payload.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把托书字段、客户上下文和拼箱上下文组装为铁路拼箱建单草案；当前不执行写入，直到 LCL payload 契约通过真实验证。 |
+| `nfe.link_order_communication` | 生成订单沟通关联草案 | `read_only` | `low` | 否 | `schemas/nfe.link_order_communication.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把订单号、邮件或消息 thread、客户/供应商沟通摘要整理成可追溯关联草案；不写 NFE、不外发。 |
+| `nfe.parse_shipment_instruction` | 解析客户托书 | `read_only` | `low` | 否 | `schemas/nfe.parse_shipment_instruction.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 读取或接收托书文本，输出客户、路线、箱型箱量、收发通、货物、价格和服务方式等结构化字段；不修改 NFE 数据。 |
+| `nfe.prepare_customer_reply_draft` | 生成客户回复草案 | `read_only` | `low` | 否 | `schemas/nfe.prepare_customer_reply_draft.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 基于订单事实、供应商更新或人工输入生成客户回复草案；不发送邮件或消息。 |
+| `nfe.query_rail_lcl_add_order_context` | 查询铁路拼箱建单上下文 | `read_only` | `low` | 否 | `schemas/nfe.query_rail_lcl_add_order_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 读取铁路拼箱新增订单前置上下文，包括拼箱舱位、港口、班列号、客户账号和 HS 风控；写接口只返回阻断边界。 |
+| `nfe.record_external_supplier_update` | 生成外部供应商更新草案 | `read_only` | `low` | 否 | `schemas/nfe.record_external_supplier_update.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把外配供应商邮件或消息中的节点、费用、订舱等更新整理成订单事实草案；不写 NFE。 |
+| `nfe.resolve_order_party_context` | 解析订单客户主体 | `read_only` | `low` | 否 | `schemas/nfe.resolve_order_party_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据托书委托人、发货人或邮箱匹配 NFE 客户、客户账号、销售和客服组候选；不唯一时返回 blocker。 |
+| `nfe.resolve_rail_route_schedule` | 解析铁路路线班列 | `read_only` | `low` | 否 | `schemas/nfe.resolve_rail_route_schedule.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据起运地、目的地、班期和箱量匹配 NFE 港口、铁路整箱班列和舱位候选；不匹配时返回 blocker。 |
+
+## 系统安全
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.get_routers` | 获取系统路由菜单树 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取当前用户登录拥有的后台路由导航菜单树，代表当前用户能访问的所有页面模块集合。 |
+| `nfe.get_user_info` | 获取当前用户信息 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取当前会话凭证登录用户的具体公司属性、角色、功能点权限等认证描述数据。 |
+
+## 业务操作
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.draft_write_operation` | 生成 NFE 写操作草案 | `read_only` | `medium` | 否 | `schemas/nfe.draft_write_operation.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 为受理订单、退仓、取消订单、发车、确认报关、申请放行、开票、收款登记等写操作生成审批草案；该能力不会修改 NFE 数据。 |
+| `nfe.execute_approved_operation` | 执行已审批 NFE 操作 | `write` | `high` | 是 | `schemas/nfe.execute_approved_operation.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 企业中枢审批后的唯一 NFE 写执行器。模型不传 approval\_id 或 approved\_by；EnterpriseTool 在进入工具包前验证一次性审批令牌。执行器只校验真实接口、预发布铁路白名单以及 execute=true/dry\_run=false。 |
+| `nfe.list_write_operations` | 查询 NFE 写操作注册表 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 列出已抓到真实 endpoint 的写操作、当前允许执行策略，以及仍被阻断的核心物流业务写操作，用于 agent 判断能否进入审批执行。 |
+| `nfe.preflight_write_operation` | 执行 NFE 写操作前置检查 | `read_only` | `medium` | 否 | `schemas/nfe.preflight_write_operation.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 按写操作类型检查真实 endpoint、payload 必填项、订单状态、单证、履约和财务前置条件，输出 blockers；通过后才能生成草案和进入企业中枢审批。 |
+
+## 业务操作系统
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.evaluate_operation_readiness` | 评估 NFE 业务操作就绪度 | `read_only` | `medium` | 否 | `schemas/nfe.evaluate_operation_readiness.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单状态、流程分支和拟操作 payload 判断受理、提货、装箱、报关、放行、发车、POD、还箱等动作是否可进入草案或审批，并返回缺失字段和阻断原因。 |
+| `nfe.get_business_flow_playbook` | 生成 NFE 业务流程作业地图 | `read_only` | `low` | 否 | `schemas/nfe.get_business_flow_playbook.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 把整箱、拼箱、箱管、报关放行、境外配送等 NFE 实际流程沉淀成机器可读的阶段、分支、角色和操作前置条件，用于 agent 判断下一步而不是反复追问用户。 |
+| `nfe.get_order_360` | 生成订单 360 业务视图 | `read_only` | `low` | 否 | `schemas/nfe.order_business_check.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 聚合订单详情、货物、箱号、报关、费用和费用审批，输出统一业务状态模型，用于 agent 一次性判断履约、单证、财务和结案条件。 |
+| `nfe.resolve_business_context` | 解析用户业务上下文 | `read_only` | `low` | 否 | `schemas/nfe.resolve_business_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据用户一句话和可检索线索判断业务意图，先查 NFE 可查数据，再推荐下一步应调用的系统级能力，减少反复追问用户。 |
+
+## 业务聚合
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.analyze_order_stage` | 分析订单当前阶段 | `read_only` | `low` | 否 | `schemas/nfe.analyze_order_stage.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单号或订单 ID 自动组合订单速查、订单详情、费用与状态字段，判断订单处于获客后下单、受理、装箱、发运、到站、单证或财务待处理等阶段，并输出风险和下一步建议。 |
+| `nfe.check_collection_status` | 检查订单回款状态 | `read_only` | `low` | 否 | `schemas/nfe.order_business_check.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单号或订单 ID 汇总收款情况、费用明细、应收台账、报价单和放行条件，用于回答是否已收款、是否可开票、是否可放行或催款。 |
+| `nfe.check_document_status` | 检查订单单证状态 | `read_only` | `low` | 否 | `schemas/nfe.order_business_check.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单号或订单 ID 汇总托书、附件、报关状态、报关方式、提单类型和放行状态，用于回答单证、报关、放行相关问题。 |
+| `nfe.check_fulfillment_status` | 检查订单履约状态 | `read_only` | `low` | 否 | `schemas/nfe.order_business_check.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单号或订单 ID 汇总订单状态、ETD、ATD、ATA、班列、箱号、装箱仓、起运港物流和目的港物流，用于回答客户“这个单到哪了”。 |
+| `nfe.detect_order_risks` | 识别订单业务风险 | `read_only` | `low` | 否 | `schemas/nfe.order_business_check.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据订单状态、报关状态、收款情况、放行状态、报价单绑定、托书和 ETD 等字段识别未报关、未结清、未放行、缺报价、缺托书、缺 ETD 等风险。 |
+| `nfe.prepare_quote_context` | 准备报价上下文 | `read_only` | `low` | 否 | `schemas/nfe.prepare_quote_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 根据客户询盘已有字段自动查询港口、国家、舱位、汇率等报价上下文，输出可继续报价的依据、缺失字段和应询问客户的最小问题集合。 |
+
+## 运营管理
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_cs_group` | 查询客服组列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取运营部门内部根据特定线路、大客户划分的专属客服组配置明细列表。 |
+| `nfe.query_loss_profit` | 查询亏损与微利列表 | `read_only` | `low` | 否 | `schemas/paged.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取运营管控中，因各种原因引发微利或者亏损异常的异常订单预警跟进日志表。 |
+| `nfe.query_loss_statistics` | 查询亏损与微利统计数据 | `read_only` | `low` | 否 | `schemas/empty.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | 获取运营管控中的亏损及微利订单总量与金额等宏观统计数据分析。 |
+
+## Atom
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.call_business_atom` | Call NFE business atom | `read_only` | `medium` | 否 | `schemas/nfe.call_business_atom.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Execute a safe-read atom or return preflight evidence for write/state-change atoms. No placeholder data is generated. |
+| `nfe.describe_business_atom` | Describe NFE business atom | `read_only` | `low` | 否 | `schemas/nfe.describe_business_atom.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Describe one atomized NFE business node, including endpoint, action class, path parameters, source files, and execution policy. |
+| `nfe.list_business_atoms` | List NFE business atoms | `read_only` | `low` | 否 | `schemas/nfe.list_business_atoms.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | List atomized business nodes generated from every cataloged NFE endpoint. Write/state-change atoms are listed but remain preflight-only. |
+
+## Auth
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.session_status` | Check NFE session status | `read_only` | `low` | 否 | `schemas/nfe.session_status.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Check whether NFE\_SATOKEN or the local NFE prerelease session file is usable before calling real business APIs. |
+
+## Catalog
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.call_api` | Call cataloged NFE API | `read_only` | `medium` | 否 | `schemas/nfe.call_api.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Call a cataloged NFE endpoint. Safe reads are allowed by default; mutations require explicit allow\_write after approval. |
+| `nfe.list_api_catalog` | List NFE API catalog | `read_only` | `low` | 否 | `schemas/nfe.list_api_catalog.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | List raw API endpoints extracted from the NFE prerelease frontend assets. |
+
+## Order
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.get_order_accept_context` | Get order accept context | `read_only` | `low` | 否 | `schemas/nfe.get_order_accept_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Fetch read-only context for an NFE orderAccept page, including core detail and best-effort related data. |
+
+## Page
+
+| Capability ID | 业务名称 | 访问 | 风险 | 审批 | 输入 Schema | 合同缺口 | 说明 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `nfe.query_car_order_list` | Query car order list | `read_only` | `low` | 否 | `schemas/nfe.query_order_page_list.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Read the real car order list used by /order/carOrderList via POST /car/booking/list. |
+| `nfe.query_order_template_list` | Query order template list | `read_only` | `low` | 否 | `schemas/nfe.query_order_page_list.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Read the real order template list used by /order/orderTemplateList via POST /bookingTemplate/list. |
+| `nfe.query_rail_fcl_add_order_context` | Query rail FCL add-order context | `read_only` | `low` | 否 | `schemas/nfe.query_rail_fcl_add_order_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Read the real page context for /order/addOrder?bookingType=FCL&transportMode=RAIL, including form contracts, selector data, train-list context when requested, and blocked write endpoints. |
+| `nfe.query_rail_order_list` | Query rail order list | `read_only` | `low` | 否 | `schemas/nfe.query_order_page_list.input.json` | 完整 | Read the real rail order list used by /order/railOrderList via POST /railBooking/list. |
+| `nfe.query_rent_container_order_list` | Query rent-container order list | `read_only` | `low` | 否 | `schemas/nfe.query_order_page_list.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Read the real rent-container order list used by /order/rentContainerOrderList via POST /rentCont/booking/list. |
+| `nfe.query_train_position_context` | Query train position context | `read_only` | `low` | 否 | `schemas/nfe.query_train_position_context.input.json` | contract, examples, error\_codes, business\_preconditions, empty\_result\_meaning | Read real train/container position context for /trainM/positionM. Missing identifiers return blockers instead of fake GPS data. |
+
+## 能力集
+
+面向 Agent 插件时不要直接依赖整包 111 个 capability，应依赖 `toolpacks/nfe-logistics/capability-sets/index.json` 中的稳定业务能力集，并在插件合同中保留解析后的 capability/operation 快照。

--- a/docs/zh-CN/fcacore-agent-plugins/plugin-runtime.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/plugin-runtime.mdx
@@ -1,0 +1,92 @@
+---
+title: "插件运行架构"
+sidebarTitle: "运行架构"
+description: "理解 FCACore 业务插件的五层合同、执行前门、发现流程和运行时目录。"
+icon: "workflow"
+---
+
+## 核心边界
+
+业务插件由五层合同组成：
+
+| 层 | 回答的问题 | 主要位置 |
+| --- | --- | --- |
+| Agent | 谁负责，负责什么结果，何时移交 | `agents/*.md` |
+| Skill | 这类任务按什么步骤完成 | `skills/<id>/` |
+| Tool | 一次调用接收什么参数、返回什么结果 | Manifest、MCP 或 ToolPack |
+| ToolPack | 一组业务能力如何授权、审批和审计 | `toolpacks/<id>/` |
+| Transport | 工具怎样连接外部系统 | HTTP、CLI、MCP、WebSocket |
+
+Agent 不应知道接口 URL、Cookie、心跳间隔或 shell 参数。它只选择稳定业务动作，例如查询客户、准备建单草稿或回读订单状态。
+
+## 运行因果
+
+```text
+用户目标
+-> Agent 校验职责
+-> Skill 收集事实并判断缺项
+-> 选择唯一执行前门
+-> JSON Schema 校验参数
+-> Adapter/ToolPack 调用外部系统
+-> 返回结构化事实或错误
+-> 写操作经过审批
+-> 独立只读回读
+-> Agent 交付证据
+```
+
+发现工具不等于完成业务动作。只有真实 HTTP、CLI、MCP、WebSocket、Browser、Computer Use 或 ToolPack 返回才能成为执行证据。
+
+## 执行前门
+
+| 条件 | 前门 |
+| --- | --- |
+| 已存在业务 ToolPack capability | `EnterpriseTool` |
+| 插件只有 1–3 个专用轻量动作 | `.fcacore-plugin` 的 `pluginCapabilities.tools` |
+| 外部服务原生提供 MCP | `.mcp.json` |
+| 需要常驻连接、订阅或共享状态 | 常驻 MCP Server 或 sidecar |
+| 操作 FCACore 内置浏览器 | `Browser*` |
+| 操作非浏览器桌面应用 | `ComputerUsePlugin` 和规范化 Computer Use 工具 |
+| 只做确定性转换 | Skill `scripts/` |
+
+同一个写操作只保留一个正式执行器，否则审批、幂等和审计无法确定最终边界。
+
+## 发现与执行
+
+插件安装后：
+
+```text
+双 Manifest 校验
+-> Agent 进入专家模板
+-> Skill 进入 Skill inventory
+-> pluginCapabilities.tools 进入能力计划
+-> .mcp.json 进入 MCP 配置
+-> 用户创建并激活 Agent
+-> 权限和审批策略在调用时生效
+```
+
+ToolPack 还有独立生命周期：
+
+```text
+install
+-> register
+-> credential/login
+-> live probe
+-> publish
+-> EnterpriseTool 可调用
+```
+
+## 运行时目录
+
+专家插件默认安装到：
+
+```text
+$FCACORE_HOME/experts/plugins/<plugin-id>/
+```
+
+未设置 `FCACORE_HOME` 时使用：
+
+```text
+~/.FCACore/experts/plugins/<plugin-id>/
+```
+
+插件命令通过 `FCACORE_PLUGIN_ROOT` 定位安装后的资源。不得依赖开发仓库的绝对路径。

--- a/docs/zh-CN/fcacore-agent-plugins/realtime-websocket.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/realtime-websocket.mdx
@@ -1,0 +1,103 @@
+---
+title: "实时 WebSocket"
+sidebarTitle: "WebSocket"
+description: "通过常驻 MCP 管理业务 WebSocket 的订阅、心跳、重连和事件游标。"
+icon: "radio"
+---
+
+## 为什么使用常驻 MCP
+
+插件命令工具每次调用启动一个短生命周期进程，无法可靠保存连接、订阅、心跳和事件游标。
+
+<Info>
+  MCP 的 WebSocket transport 负责 Agent 与 MCP Server 通信；业务 WebSocket 是 Adapter 与企业系统之间的协议，两者需要明确区分。
+</Info>
+
+模板使用：
+
+```text
+Agent
+-> MCP tool
+-> adapters/mcp-server.mjs
+-> RealtimeWsBridge
+-> Business WebSocket
+-> bounded event queue
+-> cursor poll
+```
+
+相关实现：
+
+- `adapters/realtime-ws-bridge.mjs`
+- `adapters/mcp-server.mjs`
+- `tests/plugin-kit.test.mjs`
+
+## 工具面
+
+| 工具 | 作用 | 业务副作用 |
+| --- | --- | --- |
+| `example_realtime_status` | 查看连接、队列、订阅和错误 | 无 |
+| `example_realtime_connect` | 建立常驻连接 | 无 |
+| `example_realtime_subscribe` | 订阅只读事件主题 | 无 |
+| `example_realtime_poll` | 按 cursor 非破坏性读取事件 | 无 |
+| `example_realtime_unsubscribe` | 取消订阅 | 无 |
+| `example_realtime_disconnect` | 断开并停止自动重连 | 无 |
+
+## 配置
+
+```bash
+export BUSINESS_WS_URL='wss://business.example.com/events'
+export BUSINESS_WS_TOKEN='由凭据中心注入'
+node adapters/mcp-server.mjs
+```
+
+模板只允许 localhost 使用 `ws://`，其他地址必须使用 `wss://`。
+
+## 连接行为
+
+Bridge 负责：
+
+- 鉴权消息；
+- 心跳；
+- 指数退避重连；
+- 重连后恢复只读订阅；
+- 有界内存队列；
+- 单调递增 cursor；
+- 协议错误状态。
+
+`poll` 不删除消息，消费者通过 `next_cursor` 继续读取。队列达到上限时淘汰最早事件，因此生产系统还应根据业务量设置合理上限或接入持久化事件存储。
+
+## 协议适配
+
+不同业务系统只需要替换 Bridge 内部的鉴权、订阅和事件映射，对 Agent 保持稳定工具面。
+
+不要增加“任意 topic \+ 任意 payload 发送”工具。需要写入时定义独立业务工具和窄 Schema，继续走：
+
+```text
+facts -> draft -> approval -> execute -> verify
+```
+
+断线不能自动重放未确认写入。
+
+<Warning>
+  自动重放写消息可能造成重复建单、重复扣款或重复外发。断线后必须重新读取事实并重新确认写入状态。
+</Warning>
+
+## MCP WS 与业务 WS
+
+```text
+MCP over WS = Agent 到 MCP Server 的传输
+Business WS  = Adapter 到企业系统的业务协议
+```
+
+两者不是同一协议。即使 MCP 使用 WS transport，业务事件仍需 Adapter 翻译。
+
+## 上线检查
+
+- MCP/sidecar 进程确实常驻；
+- 事件包含 cursor、接收时间、topic 和 subscription ID；
+- 队列容量和慢消费者策略明确；
+- Token 不进入日志和工具结果；
+- 生产连接启用 TLS；
+- 重启后的订阅恢复语义明确；
+- 写消息不自动重放；
+- 测试使用假 WebSocket，不连接生产系统。

--- a/docs/zh-CN/fcacore-agent-plugins/tool-integration.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/tool-integration.mdx
@@ -1,0 +1,113 @@
+---
+title: "工具与协议接入"
+description: "选择并实现 CLI、HTTP、MCP 和 WebSocket 业务工具前门。"
+icon: "plug"
+---
+
+## 选择规则
+
+| 场景 | 推荐方案 |
+| --- | --- |
+| 已有 FCACore capability | 复用 ToolPack |
+| 10 个以上相关动作、共享认证和版本 | 新建 ToolPack |
+| 插件专用的少量动作 | 插件命令工具 |
+| 服务原生支持 MCP | 配置 MCP |
+| 实时订阅或共享连接状态 | 常驻 MCP/sidecar |
+| 确定性数据转换 | Skill script |
+
+## CLI 合同
+
+```text
+AEON_TOOL_INPUT(JSON) 或 stdin
+-> 固定进程
+-> stdout 单个 JSON
+-> stderr 日志
+-> 非零退出码表示失败
+```
+
+规则：
+
+- 不使用字符串拼接 shell 参数；
+- stdout 不输出调试文本；
+- 设置超时和返回体上限；
+- 不回显环境变量和凭据；
+- 写操作不接受模型自报的审批状态。
+
+## HTTP 合同
+
+对 Agent 暴露业务动作：
+
+```text
+customer_lookup({ customer_id })
+```
+
+不要暴露：
+
+```text
+http_request({ url, method, headers, body })
+```
+
+<Warning>
+  任意 URL、Header 和 Body 会把网络边界交给模型，无法形成稳定的权限与审计合同。
+</Warning>
+
+Adapter 必须处理基础地址、认证、超时、非 2xx 错误、返回体上限和敏感日志。写请求还需要幂等键、审批作用域和写后回读。
+
+## MCP 合同
+
+插件通过 `.codex-plugin/plugin.json` 引用：
+
+```json
+{
+  "mcpServers": "./.mcp.json"
+}
+```
+
+本地 stdio MCP：
+
+```json
+{
+  "mcpServers": {
+    "business-mcp": {
+      "command": "node",
+      "args": ["./adapters/mcp-server.mjs"]
+    }
+  }
+}
+```
+
+FCACore 会把以 `./` 开头的 stdio 参数解析到插件根目录。MCP Server 至少实现：
+
+- `initialize`
+- `ping`
+- `tools/list`
+- `tools/call`
+
+工具输入必须声明 JSON Schema。业务失败返回 `isError: true` 和结构化错误。
+
+## WebSocket 合同
+
+一次性 request/response 可使用 `request_id` 关联响应。持续订阅必须放进常驻 MCP 或 sidecar，不能依赖每次调用重新启动的插件命令。
+
+生产连接使用 `wss://`。重连可以恢复只读订阅，但不能自动重放未确认写操作。完整实现见[实时 WebSocket](/zh-CN/fcacore-agent-plugins/realtime-websocket)。
+
+## 错误合同
+
+```json
+{
+  "code": "AUTH_REQUIRED",
+  "message": "业务系统登录态失效",
+  "retryable": false,
+  "details": null
+}
+```
+
+统一任务状态：
+
+| 状态 | 含义 |
+| --- | --- |
+| `completed` | 已达到验收条件 |
+| `input_required` | 缺少用户必须确认的输入 |
+| `approval_required` | 草稿完成，等待宿主审批 |
+| `blocked` | 外部依赖、权限或业务状态阻断 |
+| `failed` | 已执行但协议或业务动作失败 |

--- a/docs/zh-CN/fcacore-agent-plugins/toolpack.mdx
+++ b/docs/zh-CN/fcacore-agent-plugins/toolpack.mdx
@@ -1,0 +1,130 @@
+---
+title: "ToolPack 开发规范"
+sidebarTitle: "ToolPack"
+description: "设计可授权、可审批、可审计的企业业务 capability 和能力集。"
+icon: "package"
+---
+
+ToolPack 用于承载一个企业业务域内可授权、可审批、可审计的能力集合。大量共享认证的业务接口不应散落为插件命令。
+
+## 目录合同
+
+```text
+toolpack/
+├── manifest.json
+├── bin/
+│   ├── <platform>/tool
+│   └── <platform>/login
+├── schemas/
+├── capability-sets/
+├── workflows/
+└── agent.toml
+```
+
+`agent.toml` 是可选项。业务执行入口仍由 Manifest 决定。
+
+## Capability 合同
+
+每项能力至少声明：
+
+- `id`
+- `business_name`
+- `description`
+- `category`
+- `access_level`
+- `risk_level`
+- `approval_required`
+- `input_schema`
+- `output_schema`
+- `business_preconditions`
+- `empty_result_meaning`
+- `contract`
+- `examples`
+- `error_codes`
+
+不要把 URL 直接变成 capability。先定义业务动作、输入输出、前置条件、空结果语义、风险和回读方式。
+
+## 进程协议
+
+stdin：
+
+```json
+{
+  "request_id": "req-001",
+  "capability_id": "example.query_record",
+  "input": {
+    "record_id": "DEMO-001"
+  },
+  "context": {
+    "source": "EnterpriseTool"
+  }
+}
+```
+
+stdout：
+
+```json
+{
+  "request_id": "req-001",
+  "success": true,
+  "capability_id": "example.query_record",
+  "data": {},
+  "message": "completed"
+}
+```
+
+stdout 只输出协议 JSON，日志写 stderr。
+
+## Capability Set
+
+Agent 插件依赖业务场景能力集，不直接依赖整个 ToolPack：
+
+```json
+{
+  "id": "example.record-change/v1",
+  "capabilities": [
+    "example.health",
+    "example.query_record",
+    "example.execute_approved_change"
+  ],
+  "operations": ["record_change"],
+  "verificationCapabilities": ["example.query_record"]
+}
+```
+
+插件依赖合同：
+
+```json
+{
+  "schemaVersion": "fcacore.toolpack-requirements/v2",
+  "toolpack": "example-business",
+  "versionRange": ">=1.0.0 <2.0.0",
+  "requiredCapabilitySets": ["example.record-change/v1"],
+  "requiredCapabilities": [
+    "example.health",
+    "example.query_record",
+    "example.execute_approved_change"
+  ],
+  "requiredOperations": ["record_change"]
+}
+```
+
+`requiredCapabilities` 保存能力集解析快照，防止能力集升级后静默扩大权限。
+
+## NFE
+
+当前 NFE 入口：
+
+- 目录：`toolpacks/nfe-logistics`；
+- Agent 前门：`EnterpriseTool`；
+- 执行入口：`manifest.json` 的 `entry.command`；
+- 登录入口：`auth.login_command`；
+- 能力清单：[NFE 能力参考](/zh-CN/fcacore-agent-plugins/nfe-capabilities)。
+
+校验：
+
+```bash
+node toolpacks/nfe-logistics/scripts/validate-toolpack.mjs
+```
+
+NFE 参考由模板命令 `npm run generate:nfe-reference` 生成。


### PR DESCRIPTION
## 概要

- 在简体中文导航新增“业务 Agent 插件”栏目
- 发布 FCACore 业务 Agent 插件开发总览、运行架构、Agent/Skill/Manifest、工具协议接入与治理规范
- 补充 WebSocket、桌面/浏览器工具示例、ToolPack 开发规范和 NFE 能力参考
- 统一远端页面路径，避免本地模板路径产生失效链接

## 验证

- 本地 `npx --yes mint validate` 通过
- 本地 `npm run check` 通过（6 tests）
- Mintlify 远端 10 个页面 MDX 创建校验通过
- 导航页面数 10，孤儿页面 0
- 旧路径链接匹配数 0

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/openaeon/openaeon/editor/admin-mcp%2Ffcacore-business-agent-plugin-docs-e9b3567?preview=%2Fzh-CN%2Ffcacore-agent-plugins%2Fagent-skill-manifest&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new Chinese documentation section for FCACore business Agent plugins.
  - Added guidance for getting started, runtime architecture, plugin manifests, tools, ToolPacks, desktop/browser automation, WebSocket integrations, NFE capabilities, governance, testing, and release readiness.
  - Added navigation links and reference indexes for the new documentation pages.
  - Documented validation, approval, security, capability, and evidence-handling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->